### PR TITLE
Add $ to mediawiki::db::access params

### DIFF
--- a/manifests/db/access.pp
+++ b/manifests/db/access.pp
@@ -22,10 +22,10 @@
 # }
 #
 class mediawiki::db::access(
-  host,
-  password,
-  user     = root,
-  provider = 'mysql'
+  $host,
+  $password,
+  $user     = root,
+  $provider = 'mysql'
 ) {
 
   Class["${provider}::server"] -> Class['mediawiki::db::access']


### PR DESCRIPTION
Prior to this commit, the params in the db::access class were not
prefixed with $ signs. This causes Telly to fail.

This commit adds $ signs to beginning of those class params.
